### PR TITLE
Add support for HTTPS and hosting at arbitrary URL path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ pong -m pong_filemap -n pop_order_expandednames.txt -i ind2pop.txt
 
 Information regarding pong's application to the input data will be displayed to your terminal window. After its algorithms complete, pong initializes a web server on [localhost:4000](http://localhost:4000) (you can change the port on which pong operates with the command line option `--port`). Once you navigate to [localhost:4000](http://localhost:4000) on your web browser, pong will detect a new browser connection and begin rendering the visualization.
 
+To host the pong web server from a URL path other than "/", set the environment variable PONG_URL_PATH.
+For example, `PONG_URL_PATH=/apps/pong/` (note the trailing "/" is required) will host pong from `http://localhost:4000/apps/pong/`.
+This can be useful when the pong web server is hosted behind a reverse proxy that uses path-based routing.
 
 # Running pong on your own data
 

--- a/run_pong.py
+++ b/run_pong.py
@@ -19,7 +19,7 @@ import tornado.websocket
 sys.path.insert(0, path.join(path.dirname(__file__),'src'))
 import parse, cm, write, align, distruct
 
-
+PONG_URL_PATH=os.environ.get("PONG_URL_PATH","/")
 
 clients = []
 threads = []
@@ -281,7 +281,7 @@ def main():
 		app.listen(opts.port)
 		msg = '-----------------------------------------------------------\n'
 		msg += 'pong server is now running locally & listening on port %s\n' % opts.port
-		msg += 'Open your web browser and navigate to http://localhost:%s to see the visualization\n\n'% opts.port
+		msg += 'Open your web browser and navigate to http://localhost:%s%s to see the visualization\n\n'% (opts.port, PONG_URL_PATH)
 		sys.stdout.write(msg)
 		
 		try:
@@ -354,12 +354,13 @@ def run_pong(pongdata, opts, pong_filemap, labels, ind2pop):
 class Application(tornado.web.Application):
 	def __init__(self):
 		handlers = [
-			(r"/", MainHandler),
-			(r"/pongsocket", WSHandler),
+			(PONG_URL_PATH, MainHandler),
+			(PONG_URL_PATH + "pongsocket", WSHandler)
 		]
 		settings = dict(
 			template_path=path.join(path.dirname(__file__), "templates"),
 			static_path=path.join(path.dirname(__file__), "static"),
+			static_url_prefix=PONG_URL_PATH + 'static/',
 		)
 		tornado.web.Application.__init__(self, handlers, **settings)
 

--- a/run_pong.py
+++ b/run_pong.py
@@ -372,6 +372,9 @@ class WSHandler(tornado.websocket.WebSocketHandler):
 	global pongdata
 	clients = set()
 
+	def check_origin(self, origin):
+		return True
+
 	def open(self):
 		WSHandler.clients.add(self)
 		

--- a/static/pong.css
+++ b/static/pong.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Lato:400,400italic,700); /* aaron added */
+@import url(//fonts.googleapis.com/css?family=Lato:400,400italic,700); /* aaron added */
 
 body,h1,h2,h3,h4 {
   font-family: "Helvetica", sans-serif;

--- a/static/pong.js
+++ b/static/pong.js
@@ -94,7 +94,7 @@ $('#resize-warning-exit').click(function(){
 /* ========================================================================= */
 
 // SOCKET THINGS
-var url = "ws://" + location.host + "/pongsocket";
+var url = (location.protocol == 'https:' ? "wss://" : 'ws://') + location.host + location.pathname + "pongsocket";
 var socket = new WebSocket(url);
 var progressCount = 0;
 var numPlots = 0;
@@ -1179,7 +1179,7 @@ function saveSVG(currentPlot, is_minor, svg, runID, command) {
 	}
 
 	if (command=='svg') {
-		var svg1 = document.createElementNS('http://www.w3.org/2000/svg',
+		var svg1 = document.createElementNS('//www.w3.org/2000/svg',
 			'svg');
 
 		svg1.setAttribute('width', Math.max(popLabelDim[0], svg_bbox.width/zoom.scale()));
@@ -1253,7 +1253,7 @@ function saveAllChild(minor, command) {
 	}
 	var count = 0;
 
-	var svg1 = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+	var svg1 = document.createElementNS('//www.w3.org/2000/svg', 'svg');
 	svg1.setAttribute('width', Math.max(popLabelDim[0], svg_bbox.width/zoom.scale()));
 	svg1.setAttribute('height', (popLabelDim[1] + (svg_bbox.height + 20)*allSVGs.length));
 


### PR DESCRIPTION
The pong web server expects to be hosted at http://localhost:<port>/

This PR adds support for running pong behind a reverse proxy w/ TLS termination, hosted at an arbitrary URL path (e.g., "/apps/pong/"). In particular, this allows pong to be hosted as a web app on the [Open OnDemand](https://openondemand.org/) platform, which reverse proxies to web apps at /[r]node/(host)/(port)(path): https://osc.github.io/ood-documentation/master/app-development/interactive/view.html?highlight=rnode#reverse-proxy .

@jnovembre used this in a recent workshop.